### PR TITLE
fix: resolve dirname error in zsh environment

### DIFF
--- a/configs/zshrc-proxy
+++ b/configs/zshrc-proxy
@@ -2,7 +2,7 @@
 # 将此内容添加到 ~/.zshrc 文件中
 
 # 获取脚本所在目录
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+SCRIPT_DIR="$HOME/.setproxy"
 
 # 加载通用函数
 if [ -f "$SCRIPT_DIR/common.sh" ]; then


### PR DESCRIPTION
## 描述
修复在 zsh 环境下打开终端时出现的 `dirname: illegal option -- z` 错误。

## 相关 Issue
Fixes #1

## 改动内容
- 将 `configs/zshrc-proxy` 中的动态路径检测改为固定路径 `$HOME/.setproxy`
- 移除了使用 `BASH_SOURCE` 的代码，因为它是 Bash 特有的变量，在 zsh 中不存在

## 测试
- [x] 在 zsh 环境下测试，错误信息应该消失
- [x] proxy 命令功能正常
- [x] 安装脚本运行正常

## 影响
此修复会影响所有使用 zsh 的用户，但由于安装脚本总是将文件安装到 `~/.setproxy`，使用固定路径实际上更可靠。